### PR TITLE
Fix env var names and lint issue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Bot Configuration
-DISCORD_BOT_TOKEN=your_discord_bot_token
+DISCORD_TOKEN=your_discord_bot_token
 DISCORD_CLIENT_ID=your_discord_client_id
 DISCORD_GUILD_ID=your_discord_guild_id
 BOT_OWNERS=owner_id_1,owner_id_2

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -11,7 +11,7 @@ const __dirname = path.dirname(__filename);
 
 // Validate required environment variables
 const requiredEnvVars = [
-    'DISCORD_BOT_TOKEN',
+    'DISCORD_TOKEN',
     'GOOGLE_API_KEY'
 ];
 
@@ -23,8 +23,8 @@ for (const envVar of requiredEnvVars) {
 
 // Bot Configuration
 export const botConfig = {
-    token: process.env.DISCORD_BOT_TOKEN,
-    clientId: process.env.CLIENT_ID,
+    token: process.env.DISCORD_TOKEN,
+    clientId: process.env.DISCORD_CLIENT_ID,
     defaultPrefix: '!',
     owners: process.env.BOT_OWNERS?.split(',') || [],
     supportServer: process.env.SUPPORT_SERVER,

--- a/src/core/errorHandler.js
+++ b/src/core/errorHandler.js
@@ -5,7 +5,7 @@ import { MESSAGES } from '../constants/messages.js';
 /**
  * Custom error types
  */
-export class ValidationError extends Error {
+class ValidationError extends Error {
     constructor(message, context = {}) {
         super(message);
         this.name = 'ValidationError';
@@ -13,7 +13,7 @@ export class ValidationError extends Error {
     }
 }
 
-export class PermissionError extends Error {
+class PermissionError extends Error {
     constructor(message, context = {}) {
         super(message);
         this.name = 'PermissionError';
@@ -21,7 +21,7 @@ export class PermissionError extends Error {
     }
 }
 
-export class RateLimitError extends Error {
+class RateLimitError extends Error {
     constructor(message, context = {}) {
         super(message);
         this.name = 'RateLimitError';
@@ -29,7 +29,7 @@ export class RateLimitError extends Error {
     }
 }
 
-export class TimeoutError extends Error {
+class TimeoutError extends Error {
     constructor(message, context = {}) {
         super(message);
         this.name = 'TimeoutError';


### PR DESCRIPTION
## Summary
- use `DISCORD_TOKEN` and `DISCORD_CLIENT_ID` in configuration
- update `.env.example`
- fix duplicate export issue in `errorHandler.js`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6856d6ea1f34832ebb405a793d5257cd