### PR TITLE
Fix imports in health check module

### DIFF
--- a/src/core/healthCheck.js
+++ b/src/core/healthCheck.js
@@ -1,9 +1,9 @@
-import logger from './src/services/logger.js';
-import analytics from './src/services/analytics.js';
-import resourceManager from './src/services/resourceManager.js';
+import logger from '../services/logger.js';
+import analytics from '../services/analytics.js';
+import resourceManager from '../services/resourceManager.js';
 
-const http = require('http');
-const os = require('os');
+import http from 'http';
+import os from 'os';
 
 // Health thresholds
 const THRESHOLDS = {


### PR DESCRIPTION
## Summary
- fix relative service paths in `healthCheck.js`
- use ESM imports for `http` and `os`

## Testing
- `npm run lint` *(fails: Parsing error in src/core/errorHandler.js)*

------
https://chatgpt.com/codex/tasks/task_b_6856e26b52bc832eb7ad1d9826641bdf