### PR TITLE
Add missing error messages

### DIFF
--- a/src/constants/messages.js
+++ b/src/constants/messages.js
@@ -26,7 +26,9 @@ export const MESSAGES = {
         INVALID_MOVE: 'Invalid move.',
         NOT_YOUR_TURN: 'It is not your turn.',
         TURN_TIMEOUT: 'Your turn has timed out.',
-        GAME_TIMEOUT: 'Game has timed out due to inactivity.'
+        GAME_TIMEOUT: 'Game has timed out due to inactivity.',
+        NO_MEMORY: 'There is no stored memory for this channel.',
+        INVALID_DURATION: 'Duration must be greater than zero.'
     },
     SUCCESS: {
         COMMAND_EXECUTED: 'Command executed successfully.',


### PR DESCRIPTION
## Summary
- add `NO_MEMORY` and `INVALID_DURATION` to error message constants

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6856e27095a8832eaf210c0d1e7dbcf6